### PR TITLE
Replaced hardcoded '\\' with os.path.join

### DIFF
--- a/kep/file_io/specification.py
+++ b/kep/file_io/specification.py
@@ -27,7 +27,8 @@ def load_spec(filename):
 def _chg(template_path, filename):
     folder = os.path.split(template_path)[0]
     return os.path.join(folder, filename)
-assert _chg("temp\\_config.txt", "new.txt") == 'temp\\new.txt'
+# TODO: move this assert to unit tests
+assert _chg(os.path.join('temp', '_config.txt'), 'new.txt') == os.path.join('temp', 'new.txt')
 
 def inline_spec_load(cfg_filename, spec_file):
     return load_spec(_chg(cfg_filename, spec_file))

--- a/kep/paths.py
+++ b/kep/paths.py
@@ -1,21 +1,23 @@
 # -*- coding: utf-8 -*-
+import os
 
 # database file
-DB_FILE = 'kep/database/kep.sqlite'
+DB_FILE = os.path.join('kep', 'database', 'kep.sqlite')
 
 # output
-PDF_FILE      = 'output/monthly.pdf'
-MD_PATH       = 'output/images.md'
-PNG_FOLDER    = 'output/png'
+OUTPUT_DIR = 'output'
+PDF_FILE      = os.path.join(OUTPUT_DIR, 'monthly.pdf')
+MD_PATH       = os.path.join(OUTPUT_DIR, 'images.md')
+PNG_FOLDER    = os.path.join(OUTPUT_DIR, 'png')
 
-XLSX_FILE     = "output/kep.xlsx"
-XLS_FILE      = "output/kep.xls"
-ANNUAL_CSV    = "output/data_annual.txt"
-QUARTERLY_CSV = "output/data_qtr.txt"
-MONTHLY_CSV   = "output/data_monthly.txt"
+XLSX_FILE     = os.path.join(OUTPUT_DIR, 'kep.xlsx')
+XLS_FILE      = os.path.join(OUTPUT_DIR, 'kep.xls')
+ANNUAL_CSV    = os.path.join(OUTPUT_DIR, 'data_annual.txt')
+QUARTERLY_CSV = os.path.join(OUTPUT_DIR, 'data_qtr.txt')
+MONTHLY_CSV   = os.path.join(OUTPUT_DIR, 'data_monthly.txt')
 
 # temp folder
-SUBFOLDER = "kep\\test\\temp"
+SUBFOLDER = os.path.join('kep', 'test', 'temp')
 
 # inspection files (not used now)
-INSPECTION_FOLDER = "kep\\inspection"
+INSPECTION_FOLDER = os.path.join('kep', 'inspection')


### PR DESCRIPTION
Works fine on top of 6acd317187229226b386fbfdfc4795e62622bec4 (Wed Dec 16 17:57:51). Current `master` seems broken.
