### PR TITLE
Import problems fixed + test

### DIFF
--- a/kep/query/var_names.py
+++ b/kep/query/var_names.py
@@ -12,7 +12,7 @@ from kep.file_io.specification import load_spec
 from kep.database.db import get_unique_labels
 from kep.inspection.var_check import get_complete_dicts
 DATA_FOLDER = "data/2015/ind10"
-default_dicts = get_complete_dicts(DATA_FOLDER)
+default_dicts = None
 
 from kep.file_io.common import get_var_abbr, get_unit_abbr
 assert get_var_abbr('PROD_E_TWh') == 'PROD_E' 
@@ -36,16 +36,24 @@ def get_varnames(freq = None):
 
 # ----------------------------------------------------------------------------
 
-def get_title(name, ddict = default_dicts):
+def get_title(name, ddict=None):
+    if ddict is None:
+        global default_dicts
+        if default_dicts is None:
+            default_dicts = get_complete_dicts(DATA_FOLDER)
+        ddict = default_dicts
     title_abbr = get_var_abbr(name)
     headline_dict = ddict[0]
     for title, two_labels_list in headline_dict.items():
         if title_abbr == two_labels_list[0]:
             return title
-    return FILLER       
-assert get_title('CONSTR_yoy') == 'Объем работ по виду деятельности "Строительство"'
-assert get_title('I_bln_rub') == 'Инвестиции в основной капитал'
-assert get_title('I_yoy') == 'Инвестиции в основной капитал'
+    return FILLER
+
+# TODO: move to tests
+def test_get_title():
+    assert get_title('CONSTR_yoy') == 'Объем работ по виду деятельности "Строительство"'
+    assert get_title('I_bln_rub') == 'Инвестиции в основной капитал'
+    assert get_title('I_yoy') == 'Инвестиции в основной капитал'
 
 # ----------------------------------------------------------------------------
 

--- a/kep/test/test_import.py
+++ b/kep/test/test_import.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+import sys
+
+import kep
+
+
+def test_import_from_another_dir():
+    """
+    Test that package is importable regardless of working directory.
+
+    This is especially important for docs generation.
+    Everything should be importable without side-effects.
+    """
+    # Change to docs directory
+    project_dir = os.path.normpath(os.path.join(os.path.dirname(kep.__file__), '..'))
+    docs_dir = os.path.join(project_dir, 'docs')
+    assert os.path.isdir(docs_dir)
+    env = {'PYTHONPATH': project_dir}
+    code = 'import kep'
+    # Try to import kep from another directory in a separate python process
+    returncode = subprocess.call([sys.executable, '-c', code],
+                                 cwd=docs_dir, env=env)
+    assert returncode == 0, '`{}` failed! ' \
+                            'To find out why, try it manually ' \
+                            'from another directory.'.format(code)

--- a/kep/test/test_label_csv.py
+++ b/kep/test/test_label_csv.py
@@ -5,37 +5,53 @@ from kep.file_io.specification import load_spec, load_cfg
 from kep.importer.parser.label_csv import get_labelled_rows
 
 from kep.test.hardcoded import pass_csv_and_data, pass_spec_and_data, pass_cfg_and_data
-raw_data_file, data_as_list = pass_csv_and_data() 
-spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
-cfg_file, ref_cfg_list = pass_cfg_and_data()
+
+
+# TODO: lots of copypaste here, should use test class or something
 
 def get_test_labelled_rows():
+    raw_data_file, data_as_list = pass_csv_and_data()
+    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
+    cfg_file, ref_cfg_list = pass_cfg_and_data()
     return get_labelled_rows(raw_data_file, spec_file, cfg_file)
 
 def test_import():
+    raw_data_file, data_as_list = pass_csv_and_data()
+    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
+    cfg_file, ref_cfg_list = pass_cfg_and_data()
     assert os.path.exists(raw_data_file)
     assert os.path.exists(spec_file)
     assert os.path.exists(cfg_file)
 
 # testing with spec only   ------------------------- 
 def test_specs():
+    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
     header_dict, unit_dict = load_spec(spec_file)
     assert header_dict == ref_header_dict
     assert unit_dict == ref_unit_dict
 
 def test_label_csv1():
+    raw_data_file, data_as_list = pass_csv_and_data()
+    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
     assert data_as_list == get_labelled_rows(raw_data_file, spec_file)
 
 # testing with spec and cfg -----------------------     
 def test_segment_specs():
+    cfg_file, ref_cfg_list = pass_cfg_and_data()
     assert ref_cfg_list == load_cfg(cfg_file)
 
 def test_label_csv2():
+    raw_data_file, data_as_list = pass_csv_and_data()
+    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
+    cfg_file, ref_cfg_list = pass_cfg_and_data()
     assert data_as_list == get_labelled_rows(raw_data_file, spec_file, cfg_file)
     
 # TODO: this should be a last call, but not a test, using test_*() function is a stub. 
 #       If left plainly in code it is executed before fucntions are called and files are deleted before tests are run.
 def test_cleanup():
+    raw_data_file, data_as_list = pass_csv_and_data()
+    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
+    cfg_file, ref_cfg_list = pass_cfg_and_data()
     for f in (raw_data_file, spec_file, cfg_file):
        delete_file(f)
     assert True


### PR DESCRIPTION
Sphinx requires all your modules to be importable without major side-effects (that is, no executable code at global level).
There were two nasty problems preventing Sphinx from working properly.
1. In `var_names.py`, default dict was initialized at import time. I changed that to lazy initialization on first use. Still not very portable (it uses relative path), but at least it doesn't fail on import.
2. In `test_label_csv.py`, some test data was initialized on global level (again, using relative import described above). For now, I simply copypasted necessary calls into individual tests. We can later refactor it to use a common test class or something.

Also, I added `test_import.py` to make sure this problem won't happen again.
