### PR TITLE
Renamed hardcoded.py -> conftest.py, added test fixtures

### DIFF
--- a/kep/test/test_database.py
+++ b/kep/test/test_database.py
@@ -1,9 +1,9 @@
-from kep.test.test_stream import get_test_flat_rows
+from kep.importer.parser.stream import stream_flat_data
 from kep.query.save import get_reshaped_dfs
 from kep.database.db import stream_to_database
 
-def test_database():
-    gen = get_test_flat_rows()
+def test_database(labelled_rows):
+    gen = list(stream_flat_data(labelled_rows))
     stream_to_database(gen)
     dfa, dfq, dfm = get_reshaped_dfs()
-    assert dfa.loc[2014,'I_yoy'] == 97.3 
+    assert dfa.loc[2014, 'I_yoy'] == 97.3

--- a/kep/test/test_label_csv.py
+++ b/kep/test/test_label_csv.py
@@ -1,57 +1,26 @@
 import os
 
-from kep.file_io.common import delete_file
 from kep.file_io.specification import load_spec, load_cfg
 from kep.importer.parser.label_csv import get_labelled_rows
 
-from kep.test.hardcoded import pass_csv_and_data, pass_spec_and_data, pass_cfg_and_data
 
-
-# TODO: lots of copypaste here, should use test class or something
-
-def get_test_labelled_rows():
-    raw_data_file, data_as_list = pass_csv_and_data()
-    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
-    cfg_file, ref_cfg_list = pass_cfg_and_data()
-    return get_labelled_rows(raw_data_file, spec_file, cfg_file)
-
-def test_import():
-    raw_data_file, data_as_list = pass_csv_and_data()
-    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
-    cfg_file, ref_cfg_list = pass_cfg_and_data()
+def test_import(raw_data_file, spec_file, cfg_file):
     assert os.path.exists(raw_data_file)
     assert os.path.exists(spec_file)
     assert os.path.exists(cfg_file)
 
-# testing with spec only   ------------------------- 
-def test_specs():
-    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
+# testing with spec only   -------------------------
+def test_specs(ref_header_dict, ref_unit_dict, spec_file):
     header_dict, unit_dict = load_spec(spec_file)
     assert header_dict == ref_header_dict
     assert unit_dict == ref_unit_dict
 
-def test_label_csv1():
-    raw_data_file, data_as_list = pass_csv_and_data()
-    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
+def test_label_csv1(raw_data_file, spec_file, data_as_list):
     assert data_as_list == get_labelled_rows(raw_data_file, spec_file)
 
 # testing with spec and cfg -----------------------     
-def test_segment_specs():
-    cfg_file, ref_cfg_list = pass_cfg_and_data()
+def test_segment_specs(cfg_file, ref_cfg_list):
     assert ref_cfg_list == load_cfg(cfg_file)
 
-def test_label_csv2():
-    raw_data_file, data_as_list = pass_csv_and_data()
-    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
-    cfg_file, ref_cfg_list = pass_cfg_and_data()
+def test_label_csv2(raw_data_file, spec_file, cfg_file, data_as_list):
     assert data_as_list == get_labelled_rows(raw_data_file, spec_file, cfg_file)
-    
-# TODO: this should be a last call, but not a test, using test_*() function is a stub. 
-#       If left plainly in code it is executed before fucntions are called and files are deleted before tests are run.
-def test_cleanup():
-    raw_data_file, data_as_list = pass_csv_and_data()
-    spec_file, ref_header_dict, ref_unit_dict = pass_spec_and_data()
-    cfg_file, ref_cfg_list = pass_cfg_and_data()
-    for f in (raw_data_file, spec_file, cfg_file):
-       delete_file(f)
-    assert True

--- a/kep/test/test_stream.py
+++ b/kep/test/test_stream.py
@@ -1,8 +1,5 @@
 from kep.importer.parser.stream import stream_flat_data
-from kep.test.test_label_csv import get_test_labelled_rows
 
-def get_test_flat_rows():
-    return list(stream_flat_data(get_test_labelled_rows()))
 
 def test_flat_emitter():
     lab_rows = [['I', 'bln_rub', '2014', '13527,7', '1863,8', '2942,0', '3447,6', '5274,3', '492,2', '643,2', '728,4', '770,4', '991,1', '1180,5', '1075,1', '1168,5', '1204,0', '1468,5', '1372,5', '2433,3']   


### PR DESCRIPTION
1. Changed tests affected by https://github.com/epogrebnyak/rosstat-kep-data/pull/63 to use pytest fixtures.
2. `hardcoded.py` is renamed `conftest.py` - it's a standard pytest name which allows automatic discovery of test fixtures. All future fixtures should go there.
3. Removed `test_cleanup`, added proper finalization by `addfinalizer`.
4. Removed `if __name__ == '__main__'` part is `hardcoded.py` - looks like an obsolete debug code.
5. Moved `get_test_flat_rows` logic from `test_stream.py` because it doesn't belong there, it's only used in `test_database.py`.

If you have suggestions regarding pull request, please don't close it, just add a comment.
